### PR TITLE
feat: allow add custom atdatabase options

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,23 @@ fastify.get('/', async (request, reply) => {
 })
 ```
 
+You can also connect using full postgres connection string:
+
+```js
+const Fastify = require('fastify')
+const fastifyAtPostgres = require('fastify-at-postgres')
+
+const fastify = fastify()
+fastify.register(fastifyAtPostgres, {
+  connectionString: 'postgres://postgres:postgres@localhost:5432/my_database'
+})
+
+fastify.get('/', async (request, reply) => {
+  const result = await fastify.pg.query('SELECT * FROM contributors')  
+  reply.send(result)
+})
+```
+
 ### Instance
 
 ```js
@@ -113,7 +130,7 @@ const result = await fastify.pg.task(task)
 The plugin accepts the following options:
 
 - `host` - The hostname of the database you are connecting to. (Default: `localhost`)
-- `port` - The port number to connect to. (Default: `3306`)
+- `port` - The port number to connect to. (Default: `5432`)
 - `user` - The Postgres user to authenticate as.
 - `password` - The password of that Postgres user.
 - `database` - Name of the database to use for this connection (Optional).

--- a/index.js
+++ b/index.js
@@ -37,11 +37,12 @@ async function fastifyAtPostgres (fastify, options, next) {
     return db.tx(cb)
   }
 
-  const { host, user, password, database, port = 5432, connectionString, name } = options
+  const { host, user, password, database, port = 5432, connectionString, name, ...opts } = options
   validateOptions({ host, user, password, database, port, connectionString })
 
   const db = createConnectionPool({
-    connectionString: connectionString || buildConnectionString({ host, user, password, database, port })
+    connectionString: connectionString || buildConnectionString({ host, user, password, database, port }),
+      ...opts
   })
 
   fastify.addHook('onClose', (_, done) => {

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ async function fastifyAtPostgres (fastify, options, next) {
 
   const db = createConnectionPool({
     connectionString: connectionString || buildConnectionString({ host, user, password, database, port }),
-      ...opts
+    ...opts
   })
 
   fastify.addHook('onClose', (_, done) => {

--- a/test/connection-string.test.js
+++ b/test/connection-string.test.js
@@ -32,6 +32,12 @@ test('validateConnectionString should return true for a valid connection string'
   ok(validateConnectionString(connectionString))
 })
 
+test('validateConnectionString should return true for a valid connection string using ip address', ({ ok, plan }) => {
+  plan(1)
+
+  ok(validateConnectionString('postgres://postgres:postgres@127.0.0.1:5432/test'))
+})
+
 test('validateConnectionString should return false for an invalid connection string', ({ notOk, plan }) => {
   plan(1)
 

--- a/test/connection-string.test.js
+++ b/test/connection-string.test.js
@@ -35,7 +35,9 @@ test('validateConnectionString should return true for a valid connection string'
 test('validateConnectionString should return true for a valid connection string using ip address', ({ ok, plan }) => {
   plan(1)
 
-  ok(validateConnectionString('postgres://postgres:postgres@127.0.0.1:5432/test'))
+  const connnectionStringWithIpAddress = 'postgres://postgres:postgres@127.0.0.1:5432/test'
+
+  ok(validateConnectionString(connnectionStringWithIpAddress))
 })
 
 test('validateConnectionString should return false for an invalid connection string', ({ notOk, plan }) => {

--- a/test/fastify-postgres.test.js
+++ b/test/fastify-postgres.test.js
@@ -265,3 +265,29 @@ test('should throw with invalid type', async ({ same, teardown }) => {
     same(err.message, 'Invalid result type: invalid')
   }
 })
+
+test('fastify-at-postgres allow to pass atdatabase options', ({ error, ok, plan }) => {
+  plan(4)
+
+  const fastify = Fastify()
+
+  fastify.register(fastifyPostgres, {
+    connectionString: 'postgres://postgres:postgres@localhost:5432/test',
+    bigIntMode: 'string'
+  })
+
+  fastify.ready(async (err) => {
+    error(err)
+
+    const result = await fastify.pg.query('SELECT NOW()')
+    ok(result.length)
+
+    const numberResult = await fastify.pg.query('SELECT 1+1 as result')
+    ok(typeof numberResult[0].result === 'number')
+
+    const bigIntResult = await fastify.pg.query(`SELECT ${Number.MAX_SAFE_INTEGER} as result`)
+    ok(typeof bigIntResult[0].result === 'string')
+
+    fastify.close()
+  })
+})

--- a/test/fastify-postgres.test.js
+++ b/test/fastify-postgres.test.js
@@ -271,7 +271,7 @@ test('fastify-at-postgres allow to pass atdatabase options', ({ error, ok, plan 
 
   const fastify = Fastify()
 
-  fastify.register(fastifyPostgres, {
+  fastify.register(fastifyAtPostgres, {
     connectionString: 'postgres://postgres:postgres@127.0.0.1:5432/test',
     bigIntMode: 'string'
   })

--- a/test/fastify-postgres.test.js
+++ b/test/fastify-postgres.test.js
@@ -272,7 +272,7 @@ test('fastify-at-postgres allow to pass atdatabase options', ({ error, ok, plan 
   const fastify = Fastify()
 
   fastify.register(fastifyPostgres, {
-    connectionString: 'postgres://postgres:postgres@localhost:5432/test',
+    connectionString: 'postgres://postgres:postgres@127.0.0.1:5432/test',
     bigIntMode: 'string'
   })
 


### PR DESCRIPTION
Hi, the proposal of this PR is to allow users to use custom `atdatabase` configurations.

Message warning like this `bigIntMode currently defaults to "number" but will default to "bigint" in the next major version of @databases/pg. Set it explicitly to disable this warning.` can solved pass `bigIntMode: 'string'` to atdatabase lib.