### PR TITLE
fix: include atdatabase dependencies into depedency section

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,11 +35,11 @@
   },
   "homepage": "https://github.com/mateonunez/fastify-at-postgres#readme",
   "dependencies": {
-    "fastify-plugin": "^4.5.1"
+    "fastify-plugin": "^4.5.1",
+    "@databases/pg": "^5.5.0",
+    "@databases/sql": "3.3.0"
   },
   "devDependencies": {
-    "@databases/pg": "^5.5.0",
-    "@databases/sql": "3.3.0",
     "@fastify/pre-commit": "^2.1.0",
     "@types/node": "^20.9.0",
     "fastify": "^4.24.3",


### PR DESCRIPTION
The proposal is this PR is put `atdatabases` dependencies into `dependencies` section on `package.json` because the message ` Cannot find module '@databases/pg' Require stack` is showing up.

![ScreenShot 2023-11-10 at 07 30 06](https://github.com/mateonunez/fastify-at-postgres/assets/2390150/26fd0f70-5a6c-4c64-93c6-06fa728b3080)

I found this when update from `0.2.1` to `0.3.0`, `@databases/pg` directory into `node_modules` was removed.
